### PR TITLE
Fixed bug with negative hex constants.

### DIFF
--- a/src/idl_parser.cpp
+++ b/src/idl_parser.cpp
@@ -423,6 +423,12 @@ CheckedError Parser::Next() {
           return NoError();
         } else if (isdigit(static_cast<unsigned char>(c)) || c == '-') {
           const char *start = cursor_ - 1;
+          if (c == '-' && *cursor_ == '0' && (cursor_[1] == 'x' || cursor_[1] == 'X')) {
+            ++start;
+            ++cursor_;
+            attribute_.append(&c, &c + 1);
+            c = '0';
+          }
           if (c == '0' && (*cursor_ == 'x' || *cursor_ == 'X')) {
               cursor_++;
               while (isxdigit(static_cast<unsigned char>(*cursor_))) cursor_++;


### PR DESCRIPTION
Fixed bug, described in [#3807](https://github.com/google/flatbuffers/issues/3807).
